### PR TITLE
Update config_example.toml

### DIFF
--- a/run/config_example.toml
+++ b/run/config_example.toml
@@ -5,8 +5,8 @@ db_dir = "db"
 kv_db_dir = "kv.DB"
 
 rpc_enabled = true
-rpc_listen_address = "127.0.0.1:6789"
-zgs_node_urls = "http://127.0.0.1:5678"
+rpc_listen_address = "0.0.0.0:6789"
+zgs_node_urls = "http://localhost:5678"
 
 log_config_file = "log_config"
 


### PR DESCRIPTION
Instead of 127.0.0.1, to use 0.0.0.0 for rpc_listen_address and localhost for zgs_node_urls is more functional to enable RPC and to connect to the storage node easily.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-kv/11)
<!-- Reviewable:end -->
