### PR TITLE
Fix typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Copy the `config_example.toml` to `config.toml` and update the parameters:
 ###                   Key-Value Stream Options                      ###
 #######################################################################
 
-# In KV Senario, each independent KV database abstraction has an unique stream id.
+# In KV Scenario, each independent KV database abstraction has an unique stream id.
 
 # Streams to monitor.
 stream_ids = ["000000000000000000000000000000000000000000000000000000000000f2bd", "000000000000000000000000000000000000000000000000000000000000f009", "0000000000000000000000000000000000000000000000000000000000016879", "0000000000000000000000000000000000000000000000000000000000002e3d"]


### PR DESCRIPTION
## Pull Request Title
Fix typo in README.md

### Description
This pull request corrects a typographical error in the `README.md` file:
- Changed "Senario" to "Scenario" in the section describing the Key-Value Stream Options.

### Changes Made
- Fixed the spelling error in line 25 of the `README.md` file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/0g-storage-kv/36)
<!-- Reviewable:end -->
