### PR TITLE
config: default max_download_retries to 5 (resolves #72)

### DIFF
--- a/node/src/config/mod.rs
+++ b/node/src/config/mod.rs
@@ -46,7 +46,7 @@ build_config! {
     (wallet_private_key, (String), "".to_string())  // v2 ECIES recipient secp256k1 private key (32-byte hex)
 
     // stream data sync
-    (max_download_retries, (usize), 0) // 0 means retry forever
+    (max_download_retries, (usize), 30) // 0 = retry forever; finite default lets the fetcher skip dead txs so replay can advance past them
     (download_timeout_ms, (u64), 300000) // timeout for waiting for file locations (5 min)
     (download_retry_interval_ms, (u64), 5000) // interval between download retry attempts
     (retry_wait_ms, (u64), 1000) // wait between polling iterations in data fetcher and replayer

--- a/node/src/config/mod.rs
+++ b/node/src/config/mod.rs
@@ -46,7 +46,7 @@ build_config! {
     (wallet_private_key, (String), "".to_string())  // v2 ECIES recipient secp256k1 private key (32-byte hex)
 
     // stream data sync
-    (max_download_retries, (usize), 30) // 0 = retry forever; finite default lets the fetcher skip dead txs so replay can advance past them
+    (max_download_retries, (usize), 5) // 0 = retry forever; finite default lets the fetcher skip dead txs so replay can advance past them
     (download_timeout_ms, (u64), 300000) // timeout for waiting for file locations (5 min)
     (download_retry_interval_ms, (u64), 5000) // interval between download retry attempts
     (retry_wait_ms, (u64), 1000) // wait between polling iterations in data fetcher and replayer

--- a/run/config_example.toml
+++ b/run/config_example.toml
@@ -125,9 +125,9 @@ zgs_node_urls = ""
 
 # Max top-level retries before the fetcher gives up on a tx's download
 # and lets the replayer mark it DownloadFailed. 0 = retry forever (blocks
-# replay on any dead tx). Default 30 keeps transient outages recoverable
-# while bounding the worst-case stall to a few hours.
-# max_download_retries = 30
+# replay on any dead tx). Default 5 skips dead txs in roughly a minute of
+# fast-failure or up to ~25 min of slow-failure (file-location-timeout).
+# max_download_retries = 5
 
 # Timeout for waiting for file locations from indexer/nodes in milliseconds.
 # download_timeout_ms = 300000

--- a/run/config_example.toml
+++ b/run/config_example.toml
@@ -123,8 +123,11 @@ zgs_node_urls = ""
 ###                  Stream Data Sync Options                       ###
 #######################################################################
 
-# Max retries before skipping a failed download. 0 means retry forever.
-# max_download_retries = 0
+# Max top-level retries before the fetcher gives up on a tx's download
+# and lets the replayer mark it DownloadFailed. 0 = retry forever (blocks
+# replay on any dead tx). Default 30 keeps transient outages recoverable
+# while bounding the worst-case stall to a few hours.
+# max_download_retries = 30
 
 # Timeout for waiting for file locations from indexer/nodes in milliseconds.
 # download_timeout_ms = 300000


### PR DESCRIPTION
Resolves #72.

Default `max_download_retries` was `0` (retry forever), which froze replay on any anchored-but-undelivered tx and prevented `kv_getTransactionResult` from ever returning `DownloadFailed`. Switching to `5` lets the data fetcher skip dead txs after a short bounded wait, which is what `kv_getReplayProgress` callers (e.g. the S3 gateway use case from #67) need to distinguish transient lag from permanent miss.

## Changes

- `node/src/config/mod.rs`: default `5`.
- `run/config_example.toml`: comment now describes what the value actually controls (top-level fetcher retries, not per-segment retries) and reflects the new default.

No code-path changes. Operators who explicitly set the value in their config are unaffected.

## Timing math

| max_download_retries | min stall before skip | max stall (file-location-timeout path) |
|---|---|---|
| 5 (new default) | ~1 min | ~25 min |
| 0 (previous) | n/a | forever |

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] Optional: a deployment on devnet to confirm a tx with intentionally-missing data flips to `DownloadFailed` after ~5 retries and replay advances