### PR TITLE
fix(stream): start node iteration at clients[0] (resolves #74)

### DIFF
--- a/node/stream/src/stream_manager/stream_data_fetcher.rs
+++ b/node/stream/src/stream_manager/stream_data_fetcher.rs
@@ -292,7 +292,7 @@ impl StreamDataFetcher {
 
         // Build DownloadContext with optional encryption
         let ctx = {
-            let base = DownloadContext::new(clients, 1, file_info, tx.data_merkle_root)?;
+            let base = DownloadContext::new(clients, 0, file_info, tx.data_merkle_root)?;
             if let Some(key) = &self.config.encryption_key {
                 base.with_encryption(*key)
             } else if let Some(priv_key) = &self.config.wallet_private_key {


### PR DESCRIPTION
Resolves #74.

Change the SDK \`routines\` arg from \`1\` to \`0\` so the round-robin starts at the first configured node, matching how operators expect \`zgs_node_urls\` ordering to behave.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean