### PR TITLE
chore(rpc): drop duplicate idempotent-hit log in admin_addStream (resolves #76)

### DIFF
--- a/node/rpc/src/admin_rpc_server/impl.rs
+++ b/node/rpc/src/admin_rpc_server/impl.rs
@@ -65,7 +65,9 @@ impl AdminRpcServer for AdminRpcServerImpl {
         // deadlocks.
         let mut live = self.live_stream_set.write().await;
         if live.contains(&stream_id) {
-            debug!("admin_addStream idempotent hit for {:?}", stream_id);
+            // Race-loser path: another caller registered the same id between
+            // our fast-path read and this write-lock acquisition. No log —
+            // the fast-path debug covers the common idempotent case.
             return Ok(true);
         }
         live.insert(stream_id);


### PR DESCRIPTION
Resolves #76.

The fast-path debug log in \`admin_addStream\` already covers the common idempotent re-add. The same line under the write lock fired only on a race between fast-path-read and write-lock-acquire; logging it identically obscured that distinction. Drop the slow-path log and leave a one-line comment for context.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean