### PR TITLE
fix(log_sync): retry on transient 5xx / HTML proxy errors instead of crashing (resolves #80)

### DIFF
--- a/node/log_entry_sync/src/sync_manager/log_entry_fetcher.rs
+++ b/node/log_entry_sync/src/sync_manager/log_entry_fetcher.rs
@@ -1,4 +1,5 @@
 use crate::sync_manager::log_query::LogQuery;
+use crate::sync_manager::retry_policy::TransientRpcRetryPolicy;
 use crate::sync_manager::{metrics, RETRY_WAIT_MS};
 use crate::{ContractAddress, LogSyncConfig};
 use anyhow::{anyhow, bail, Result};
@@ -6,7 +7,7 @@ use append_merkle::{Algorithm, Sha3Algorithm};
 use contract_interface::{SubmissionNode, SubmitFilter, ZgsFlow};
 use ethers::abi::RawLog;
 use ethers::prelude::{BlockNumber, EthLogDecode, Http, Middleware, Provider};
-use ethers::providers::{HttpRateLimitRetryPolicy, RetryClient, RetryClientBuilder};
+use ethers::providers::{RetryClient, RetryClientBuilder};
 use ethers::types::{Block, Log, H160, H256};
 use futures::StreamExt;
 use jsonrpsee::tracing::{debug, error, info, warn};
@@ -46,7 +47,7 @@ impl LogEntryFetcher {
                             .connect_timeout(config.blockchain_rpc_timeout)
                             .build()?,
                     ),
-                    Box::new(HttpRateLimitRetryPolicy),
+                    Box::new(TransientRpcRetryPolicy),
                 ),
         ));
         // TODO: `error` types are removed from the ABI json file.

--- a/node/log_entry_sync/src/sync_manager/mod.rs
+++ b/node/log_entry_sync/src/sync_manager/mod.rs
@@ -565,3 +565,4 @@ pub(crate) mod config;
 mod log_entry_fetcher;
 mod log_query;
 mod metrics;
+mod retry_policy;

--- a/node/log_entry_sync/src/sync_manager/retry_policy.rs
+++ b/node/log_entry_sync/src/sync_manager/retry_policy.rs
@@ -1,0 +1,122 @@
+use ethers::providers::{HttpClientError, HttpRateLimitRetryPolicy, RetryPolicy};
+use reqwest::StatusCode;
+use std::time::Duration;
+
+/// Retry policy that broadens ethers' built-in `HttpRateLimitRetryPolicy` to
+/// cover the transient errors that are most common when talking to a chain
+/// RPC through a reverse proxy:
+///
+/// - reqwest connection / timeout errors
+/// - any HTTP 5xx (502 / 503 / 504 are routinely emitted by openresty/nginx
+///   when the upstream node restarts or briefly stalls)
+/// - SerdeJson deserialization failures whose body is HTML — i.e. a proxy
+///   returned an error page instead of a JSON-RPC envelope
+///
+/// Everything narrower (specifically: HTTP 429, the rate-limit JSON-RPC
+/// error codes, and JsonRpcError envelopes hidden inside a SerdeJson body)
+/// is delegated to `HttpRateLimitRetryPolicy` so we don't drop existing
+/// behaviour on the floor.
+#[derive(Debug)]
+pub struct TransientRpcRetryPolicy;
+
+impl RetryPolicy<HttpClientError> for TransientRpcRetryPolicy {
+    fn should_retry(&self, error: &HttpClientError) -> bool {
+        match error {
+            HttpClientError::ReqwestError(err) => {
+                if err.is_timeout() || err.is_connect() {
+                    return true;
+                }
+                if let Some(status) = err.status() {
+                    if status.is_server_error() || status == StatusCode::TOO_MANY_REQUESTS {
+                        return true;
+                    }
+                }
+            }
+            HttpClientError::SerdeJson { text, .. } => {
+                // HTML body = a proxy returned its own error page (e.g.
+                // "<html>...502 Bad Gateway...openresty..."). Always
+                // transient.
+                if text.trim_start().starts_with('<') {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+        // Fall through to the narrow rate-limit policy for the cases we
+        // haven't broadened (HTTP 429, JSON-RPC rate-limit codes, etc.).
+        HttpRateLimitRetryPolicy.should_retry(error)
+    }
+
+    fn backoff_hint(&self, error: &HttpClientError) -> Option<Duration> {
+        HttpRateLimitRetryPolicy.backoff_hint(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethers::providers::JsonRpcError;
+
+    /// Build a `SerdeJson` variant with an arbitrary `text` body. The error
+    /// itself is produced by deliberately failing to parse the text as
+    /// `()` — which only accepts `null`, so any other input yields a real
+    /// `serde_json::Error`. The text we put into the variant is decoupled
+    /// from the parse attempt, so it can be anything.
+    fn serde_json_error(text: &str) -> HttpClientError {
+        let err = serde_json::from_str::<()>("invalid").expect_err("must not parse");
+        HttpClientError::SerdeJson {
+            err,
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn retries_on_html_body() {
+        let err = serde_json_error("<html><head><title>502 Bad Gateway</title></head></html>");
+        assert!(TransientRpcRetryPolicy.should_retry(&err));
+    }
+
+    #[test]
+    fn retries_on_html_body_with_leading_whitespace() {
+        let err = serde_json_error("   \n<html>oops</html>");
+        assert!(TransientRpcRetryPolicy.should_retry(&err));
+    }
+
+    #[test]
+    fn does_not_retry_on_genuinely_malformed_json() {
+        // Body parses as nothing useful but isn't an HTML page either —
+        // probably a real bug, don't retry.
+        let err = serde_json_error("not json, not html, just garbage");
+        assert!(!TransientRpcRetryPolicy.should_retry(&err));
+    }
+
+    #[test]
+    fn delegates_to_inner_for_jsonrpc_envelope_in_serdejson_text() {
+        // Even though the body fails strict JSON-RPC parsing, the inner
+        // policy recognises the embedded JsonRpcError with a known
+        // rate-limit message and retries.
+        let body = r#"{"error":{"code":-32005,"message":"limit"}}"#;
+        let err = serde_json_error(body);
+        assert!(TransientRpcRetryPolicy.should_retry(&err));
+    }
+
+    #[test]
+    fn retries_on_rate_limit_jsonrpc_code() {
+        let err = HttpClientError::JsonRpcError(JsonRpcError {
+            code: -32005,
+            message: "project rate limit".into(),
+            data: None,
+        });
+        assert!(TransientRpcRetryPolicy.should_retry(&err));
+    }
+
+    #[test]
+    fn does_not_retry_on_unknown_jsonrpc_error() {
+        let err = HttpClientError::JsonRpcError(JsonRpcError {
+            code: -32000,
+            message: "execution reverted".into(),
+            data: None,
+        });
+        assert!(!TransientRpcRetryPolicy.should_retry(&err));
+    }
+}


### PR DESCRIPTION
Resolves #80.

ethers' \`HttpRateLimitRetryPolicy\` only retries on HTTP 429 and a few specific JSON-RPC rate-limit error codes. In production a much more common failure is a 502/503/504 from a reverse proxy (\`openresty\`/nginx) when the chain RPC upstream blips — and when that response body is HTML, the error surfaces as \`HttpClientError::SerdeJson\` with the HTML in \`text\`. The narrow policy returns \`false\`, the error propagates through every \`get_block(...).await?\` in \`sync_manager/mod.rs\`, and the log-sync future ends with \`ShutdownReason::Failure("log sync failure")\` — terminating the entire KV process.

This PR adds \`TransientRpcRetryPolicy\` that broadens the retryable set to:

- \`reqwest::Error::is_timeout()\` / \`is_connect()\`
- HTTP 5xx and 429 status codes  
- \`SerdeJson\` errors whose body starts with \`<\` (HTML proxy error page)

Narrower existing cases (JSON-RPC rate-limit codes, \`JsonRpcError\` envelopes hidden inside \`SerdeJson\` text) still delegate to \`HttpRateLimitRetryPolicy\` so we don't drop coverage. \`backoff_hint\` also delegates so Infura's rate-backoff data still gets honoured.

## Changes

- \`node/log_entry_sync/src/sync_manager/retry_policy.rs\` — new file, \`TransientRpcRetryPolicy\` + 6 unit tests
- \`node/log_entry_sync/src/sync_manager/mod.rs\` — register submodule
- \`node/log_entry_sync/src/sync_manager/log_entry_fetcher.rs\` — swap \`HttpRateLimitRetryPolicy\` → \`TransientRpcRetryPolicy\` at the single \`RetryClientBuilder::build\` call site

No config changes. The existing \`rate_limit_retries\` / \`timeout_retries\` / \`initial_backoff\` knobs apply unchanged.

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] 6 unit tests pass (\`cargo test -p log_entry_sync retry_policy::\`):
  - retries on HTML body (typical openresty 502 page)
  - retries on HTML body with leading whitespace
  - does not retry on genuinely malformed JSON
  - delegates to inner for JsonRpcError envelope embedded in SerdeJson text
  - retries on rate-limit JSON-RPC code (-32005)
  - does not retry on unknown JSON-RPC error (-32000 execution reverted)
- [ ] Optional: a manual smoke test under a flaky chain RPC to confirm the KV stays up across transient 502s instead of shutting down