### PR TITLE
ci: cap CARGO_BUILD_JOBS=2 in cc.yml so coverage build fits in 7GB (resolves #82)

### DIFF
--- a/.github/workflows/cc.yml
+++ b/.github/workflows/cc.yml
@@ -40,6 +40,10 @@ jobs:
       run: cargo test --no-fail-fast
       env:
         CARGO_INCREMENTAL: '0'
+        # Cap parallel rustc/ld processes so coverage-instrumented link steps
+        # (admin_add_stream_e2e.rs and friends) fit in the runner's ~7 GB.
+        # Without this, default jobs=4 OOMs at link time. See #82.
+        CARGO_BUILD_JOBS: '2'
         RUSTC_BOOTSTRAP: '1'
         RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
         RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'


### PR DESCRIPTION
Resolves #82.

Since 2026-05-13 the \`code-coverage\` workflow has been failing with exit 143 (SIGTERM, OOM) mid-build. Root cause is in #82 — TL;DR: PR #68 added the first \`tests/*.rs\` integration test binary (\`admin_add_stream_e2e\`), which under \`-Zprofile -Clink-dead-code -Copt-level=0\` holds a ~1–2 GB working set during \`ld\`. With \`CARGO_BUILD_JOBS\` defaulting to 4 those link processes run in parallel and overrun \`ubuntu-latest\`'s ~7 GB RAM.

This PR caps \`CARGO_BUILD_JOBS\` to \`2\` in the unittest-cov job's env. Cuts peak link RAM roughly in half at the cost of ~1–2 min wall time.

## Changes

\`\`\`yaml
# .github/workflows/cc.yml
env:
  CARGO_INCREMENTAL: '0'
+ # Cap parallel rustc/ld processes so coverage-instrumented link steps
+ # (admin_add_stream_e2e.rs and friends) fit in the runner's ~7 GB.
+ # Without this, default jobs=4 OOMs at link time. See #82.
+ CARGO_BUILD_JOBS: '2'
  RUSTC_BOOTSTRAP: '1'
\`\`\`

No code, dep, or other workflow changes. Only this job uses these flags; the \`rust.yml\` and \`tests.yml\` workflows are unaffected.

## Test plan

The proof is in the next coverage run on this PR — if it goes green (or at least gets past link-time without exit 143) the fix is working. If 2 still flakes, the follow-up is \`CARGO_BUILD_JOBS: 1\`.